### PR TITLE
Fix Tailwind CSS v4 PostCSS configuration

### DIFF
--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,5 +1,5 @@
-const config = {
-  plugins: ["@tailwindcss/postcss"],
+module.exports = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
 };
-
-export default config;


### PR DESCRIPTION
## Summary

Fixed the frontend build failure caused by incorrect PostCSS configuration for Tailwind CSS v4.

## Changes

- Updated `postcss.config.js` to use CommonJS syntax for NX compatibility
- Changed plugins from array to object format as required by Tailwind v4
- Used proper `@tailwindcss/postcss` plugin configuration

## References

- Fixes #7
- Based on [Tailwind v4 Angular docs](https://tailwindcss.com/docs/installation/framework-guides/angular)

Generated with [Claude Code](https://claude.ai/code)